### PR TITLE
 fix: change const to let for reassigned variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geographiclib-mgrs",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geographiclib-mgrs",
-      "version": "1.0.0",
+      "version": "1.0.4",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.0",

--- a/src/transverse-mercator.mjs
+++ b/src/transverse-mercator.mjs
@@ -281,7 +281,7 @@ const TransverseMercator = {
   forward(lon0, lat, lon) {
     lat = MATH.latFix(lat);
     lon = MATH.angDiff(lon0, lon);
-    const latsign = Math.sign(lat);
+    let latsign = Math.sign(lat);
     const lonsign = Math.sign(lon);
     lon *= lonsign;
     lat *= latsign;

--- a/src/utility.mjs
+++ b/src/utility.mjs
@@ -67,7 +67,7 @@ const UTILITY = {
     let y1,
       m1 = 1,
       d1 = 1;
-    const p1 = s.search(/[^0-9]/);
+    let p1 = s.search(/[^0-9]/);
     if (p1 === -1) y1 = parseInt(s);
     else if (s[p1] !== "-")
       throw new Error("Delimiter not hyphen in date " + s);


### PR DESCRIPTION
                                                                                                         
  ## Summary

  - `p1` in `utility.mjs` (line 70) is declared as `const` but mutated with `++p1` on lines 77 and 85
  - `latsign` in `transverse-mercator.mjs` (line 284) is declared as `const` but reassigned on line 290

  These are technically invalid JavaScript — they work in some runtimes that don't enforce `const` strictly, but **esbuild** (used
   by Vite, Remix, etc.) performs static analysis and rejects them at build time, making the package unusable in those toolchains.

  ## Fix

  Changed `const` to `let` for both variables.

  ## How to reproduce

  Install `geographiclib-mgrs` in any project using Vite or esbuild as a bundler:

  ✘ [ERROR] Cannot assign to "p1" because it is a constant
  ✘ [ERROR] Cannot assign to "latsign" because it is a constant