### PR TITLE
Fix TypeScript declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,33 +1,39 @@
-declare module "mgrs" {
-  /**
-   * Convert lat/lon to MGRS.
-   *
-   * @param {[number, number]} ll Array with longitude and latitude on a
-   *     WGS84 ellipsoid.
-   * @param {number} [accuracy=5] Accuracy in digits (5 for 1 m, 4 for 10 m, 3 for
-   *      100 m, 2 for 1 km, 1 for 10 km or 0 for 100 km). Optional, default is 5.
-   * @return {string} the MGRS string for the given location and accuracy.
-   */
-  export function forward(ll: [number, number], accuracy?: number): string;
+/**
+ * Convert lat/lon to MGRS.
+ *
+ * @param {[number, number]} ll Array with longitude and latitude on a
+ *     WGS84 ellipsoid.
+ * @param {number} [accuracy=5] Accuracy in digits (5 for 1 m, 4 for 10 m, 3 for
+ *      100 m, 2 for 1 km, 1 for 10 km or 0 for 100 km). Optional, default is 5.
+ * @return {string} the MGRS string for the given location and accuracy.
+ */
+declare function forward(ll: [number, number], accuracy?: number): string;
 
-  /**
-   * Convert MGRS to lat/lon bounding box.
-   *
-   * @param {string} mgrs MGRS string.
-   * @return {[number,number,number,number]} An array with left (longitude),
-   *    bottom (latitude), right
-   *    (longitude) and top (latitude) values in WGS84, representing the
-   *    bounding box for the provided MGRS reference.
-   */
-  export function inverse(mgrs: string): [number, number, number, number];
+/**
+ * Convert MGRS to lat/lon bounding box.
+ *
+ * @param {string} mgrs MGRS string.
+ * @return {[number,number,number,number]} An array with left (longitude),
+ *    bottom (latitude), right
+ *    (longitude) and top (latitude) values in WGS84, representing the
+ *    bounding box for the provided MGRS reference.
+ */
+declare function inverse(mgrs: string): [number, number, number, number];
 
-  /**
-   * Convert MGRS to lat/lon point.
-   *
-   * @param {string} mgrs MGRS string.
-   * @param {bool} [centerpoint=true] If we should use the center point or lower left corner
-   * @return {[number,number]} An array with longitude and latitude values in
-   *    WGS84, representing the center point of the provided MGRS reference.
-   */
-  export function toPoint(mgrs: string, centerpoint?: bool): [number, number];
-}
+/**
+ * Convert MGRS to lat/lon point.
+ *
+ * @param {string} mgrs MGRS string.
+ * @param {boolean} [centerpoint=true] If we should use the center point or lower left corner
+ * @return {[number,number]} An array with longitude and latitude values in
+ *    WGS84, representing the center point of the provided MGRS reference.
+ */
+declare function toPoint(mgrs: string, centerpoint?: boolean): [number, number];
+
+declare const _default: {
+  forward: typeof forward;
+  inverse: typeof inverse;
+  toPoint: typeof toPoint;
+};
+
+export default _default;


### PR DESCRIPTION
Thank you for your package.

When consuming it with TypeScript, I encountered typing errors. I was wondering if it would be possible to update the declaration file.

The previous `index.d.ts` used an ambient module declaration (`declare module "mgrs" { ... }`) which conflicts with how the package is consumed when imported as an ES module or bundled. Users importing the package get typing errors or no type resolution at all. The new declarations align with the actual runtime shape of the module.